### PR TITLE
Use nodejs-14_x (fixes terminal)

### DIFF
--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -21,7 +21,7 @@ with lib;
         PATH=${makeBinPath (with pkgs; [ coreutils inotify-tools ])}
         bin_dir=~/.vscode-server/bin
         [[ -e $bin_dir ]] &&
-        find "$bin_dir" -mindepth 2 -maxdepth 2 -name node -type f -exec ln -sfT ${pkgs.nodejs-12_x}/bin/node {} \; ||
+        find "$bin_dir" -mindepth 2 -maxdepth 2 -name node -type f -exec ln -sfT ${pkgs.nodejs-14_x}/bin/node {} \; ||
         mkdir -p "$bin_dir"
         while IFS=: read -r bin_dir event; do
           # A new version of the VS Code Server is being created.
@@ -29,7 +29,7 @@ with lib;
             # Create a trigger to know when their node is being created and replace it for our symlink.
             touch "$bin_dir/node"
             inotifywait -qq -e DELETE_SELF "$bin_dir/node"
-            ln -sfT ${pkgs.nodejs-12_x}/bin/node "$bin_dir/node"
+            ln -sfT ${pkgs.nodejs-14_x}/bin/node "$bin_dir/node"
           # The monitored directory is deleted, e.g. when "Uninstall VS Code Server from Host" has been run.
           elif [[ $event == DELETE_SELF ]]; then
             # See the comments above Restart in the service config.


### PR DESCRIPTION
The terminal inside VSCode stopped working because the node module responsible for it has been compiled with `NODE_MODULE_VERSION=83` which is incompatible with NodeJS 12. Updating the NodeJS version to 14 fixes the issue