### PR TITLE
Update nodejs-12_x references to nodejs-14_x

### DIFF
--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -21,7 +21,7 @@ with lib;
         PATH=${makeBinPath (with pkgs; [ coreutils inotify-tools ])}
         bin_dir=~/.vscode-server/bin
         [[ -e $bin_dir ]] &&
-        find "$bin_dir" -mindepth 2 -maxdepth 2 -name node -type f -exec ln -sfT ${pkgs.nodejs-12_x}/bin/node {} \; ||
+        find "$bin_dir" -mindepth 2 -maxdepth 2 -name node -type f -exec ln -sfT ${pkgs.nodejs-14_x}/bin/node {} \; ||
         mkdir -p "$bin_dir"
         while IFS=: read -r bin_dir event; do
           # A new version of the VS Code Server is being created.
@@ -29,7 +29,7 @@ with lib;
             # Create a trigger to know when their node is being created and replace it for our symlink.
             touch "$bin_dir/node"
             inotifywait -qq -e DELETE_SELF "$bin_dir/node"
-            ln -sfT ${pkgs.nodejs-12_x}/bin/node "$bin_dir/node"
+            ln -sfT ${pkgs.nodejs-14_x}/bin/node "$bin_dir/node"
           # The monitored directory is deleted, e.g. when "Uninstall VS Code Server from Host" has been run.
           elif [[ $event == DELETE_SELF ]]; then
             # See the comments above Restart in the service config.


### PR DESCRIPTION
As of VSCode version 1.56.0, VSCode is using node version 14. In order to avoid NODE_MODULE_VERSION errors, it's necessary to update the symlink to point to nodejs-14_x.