### PR TITLE
Add extensions config option

### DIFF
--- a/modules/vscode-server/home.nix
+++ b/modules/vscode-server/home.nix
@@ -1,4 +1,4 @@
-import ./module.nix ({ name, description, serviceConfig }:
+import ./module.nix ({ name, description, serviceConfig, extensions }:
 
 {
   systemd.user.services.${name} = {
@@ -12,4 +12,6 @@ import ./module.nix ({ name, description, serviceConfig }:
       WantedBy = [ "default.target" ];
     };
   };
+
+  home.file = extensions;
 })


### PR DESCRIPTION
Adds 2 options for managing extensions to fix #11 

`services.vscode-server.extensions`: a list of extensions that will be installed to `~/.vscode-server/extensions` from nixpkgs
`services.vscode-server.immutableExtensionsDir`: whether extensions can only be modified by home manager (by symlinking to the combined extensions derivation)

I was able to copy most of the logic from https://github.com/nix-community/home-manager/blob/master/modules/programs/vscode.nix, there is no difference in how vscode and vscode-server stores extensions (besides the path).

Everything appears to be working correctly, the `vscode-extensions.ms-vscode.cpptool` extension can run its nixified binary and the extensions directory can exist before the server is downloaded so vscode won't try to delete them.

