### PR TITLE
Update ripgrep package name

### DIFF
--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -24,7 +24,7 @@ with lib;
         # Fix any existing symlinks before we enter the inotify loop.
         if [[ -e $bin_dir ]]; then
           find "$bin_dir" -mindepth 2 -maxdepth 2 -name node -exec ln -sfT ${pkgs.nodejs-16_x}/bin/node {} \;
-          find "$bin_dir" -path '*/vscode-ripgrep/bin/rg' -exec ln -sfT ${pkgs.ripgrep}/bin/rg {} \;
+          find "$bin_dir" -path '*/@vscode/ripgrep/bin/rg' -exec ln -sfT ${pkgs.ripgrep}/bin/rg {} \;
         else
           mkdir -p "$bin_dir"
         fi
@@ -36,7 +36,7 @@ with lib;
             touch "$bin_dir/node"
             inotifywait -qq -e DELETE_SELF "$bin_dir/node"
             ln -sfT ${pkgs.nodejs-16_x}/bin/node "$bin_dir/node"
-            ln -sfT ${pkgs.ripgrep}/bin/rg "$bin_dir/node_modules/vscode-ripgrep/bin/rg"
+            ln -sfT ${pkgs.ripgrep}/bin/rg "$bin_dir/node_modules/@vscode/ripgrep/bin/rg"
           # The monitored directory is deleted, e.g. when "Uninstall VS Code Server from Host" has been run.
           elif [[ $event == DELETE_SELF ]]; then
             # See the comments above Restart in the service config.


### PR DESCRIPTION
Hi there! I hope all is well.

Looks like vscode changed the name of the package they use for ripgrep and it broke my search in aarch64 again. I updated it and it's working on my setup so I thought I would put it up here in case it helps!

(Also, sorry for the mess I caused in the previous PR, guess I wasn't paying enough attention 😅)