### PR TITLE
feat: add flake output

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Experimental support for VS Code Server in NixOS. The NodeJS by default supplied
 
 ## Installation
 
+### NixOS module
+
+You can add the module to your system in various ways. After the installation
+you'll have to manually enable the service for each user (see below).
+
+#### Install as a tarball
+
 ```nix
 {
   imports = [
@@ -13,6 +20,27 @@ Experimental support for VS Code Server in NixOS. The NodeJS by default supplied
   services.vscode-server.enable = true;
 }
 ```
+
+#### Install as a flake
+
+```nix
+{
+  inputs.vscode-server.url = "github:msteen/nixos-vscode-server";
+
+  outputs = { self, nixpkgs, vscode-server }: {
+    nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
+      modules = [
+        vscode-server.nixosModule
+        ({ config, pkgs, ... }: {
+          services.vscode-server.enable = true;
+        })
+      ];
+    };
+  };
+}
+```
+
+#### Enable the service
 
 And then enable them for the relevant users:
 
@@ -26,7 +54,7 @@ You will see the following message:
 The unit files have no installation config (WantedBy=, RequiredBy=, Also=,
 Alias= settings in the [Install] section, and DefaultInstance= for template
 units). This means they are not meant to be enabled using systemctl.
- 
+
 Possible reasons for having this kind of units are:
 • A unit may be statically enabled by being symlinked from another unit's
   .wants/ or .requires/ directory.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1655361562,
+        "narHash": "sha256-chPaIIhmdL6jdZWpf/K6yQCsuBNOYuMqbJsNpLfrdTE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0b59d075675dc28bf9ebab466033280096c8d4fe",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,8 @@
+{
+  description = "NixOS VSCode server";
+
+  outputs = { self, nixpkgs }: {
+    nixosModule = import ./modules/vscode-server;
+    nixosModules.default = self.nixosModule;
+  };
+}


### PR DESCRIPTION
Hello, I created this flake output for my own use and thought I'd contribute it back. I saw that PR #5 also adds a flake output but it hasn't been touched in over a year and also has a bunch of other (very useful tbf) changes.

This is how I'm using the flake https://github.com/alexghr/nix/commit/3009bff7bcbea819892720bffe1b7f859ad683f0. It shouldn't affect existing users of the NixOS module.

Feel free to close this if you're waiting for the other PR.