### PR TITLE
Add home manager module to flake outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ you'll have to manually enable the service for each user (see below).
         ({ config, pkgs, ... }: {
           services.vscode-server.enable = true;
         })
+        home-manager.nixosModules.home-manager
+        {
+          home-manager.users.jdoe = {
+            imports = [
+              vscode-server.homeManagerModule
+            ]
+            services.vscode-server.enable = true;
+          };
+        }
       ];
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -4,5 +4,7 @@
   outputs = { self, nixpkgs }: {
     nixosModule = import ./modules/vscode-server;
     nixosModules.default = self.nixosModule;
+    homeManagerModule = import ./modules/vscode-server/home.nix;
+    homeManagerModules.default = self.homeManagerModule;
   };
 }


### PR DESCRIPTION
It looks like the NixOS module was made available for flakes, but the home manager module was not. This change adds it to the flake outputs and updates the documentation to show how to use it.