### PR TITLE
Configurable server location

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,27 @@ Put this code into your [home-manager](https://github.com/nix-community/home-man
 
 When the service is enabled and running it should simply work, there is nothing for you to do.
 
+
+#### Custom server path
+
+A remote server location can be customized from the default `~/.vscode-server` in your `settings.json`, for example:
+
+```jsonc
+{
+  // ...
+  "remote.SSH.serverInstallPath": {
+    "HOSTNAME": "/home/USER/.local/share",
+  }
+}
+```
+
+To reflect these changes in your configuration set the following option:
+
+```nix
+services.vscode-server.enable = true;
+services.vscode-server.path = "~/.local/share/.vscode-server";
+```
+
 ## Troubleshooting
 
 This is not really an issue with this project per se, but with systemd user services in NixOS in general. After updating it can be necessary to first disable the service again:

--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -9,8 +9,8 @@ with lib;
     path = mkOption {
       description = "Path to the server root location";
       type = types.str;
+      default = "~/.vscode-server";
     };
-    default = "~/.vscode-server";
   };
 
   config = lib.mkIf config.services.vscode-server.enable (moduleConfig rec {

--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -4,7 +4,14 @@ moduleConfig:
 with lib;
 
 {
-  options.services.vscode-server.enable = with types; mkEnableOption "VS Code Server";
+  options.services.vscode-server = {
+    enable = with types; mkEnableOption "VS Code Server";
+    path = mkOption {
+      description = "Path to the server root location";
+      type = types.str;
+    };
+    default = "~/.vscode-server";
+  };
 
   config = lib.mkIf config.services.vscode-server.enable (moduleConfig rec {
     name = "auto-fix-vscode-server";
@@ -19,7 +26,7 @@ with lib;
       ExecStart = "${pkgs.writeShellScript "${name}.sh" ''
         set -euo pipefail
         PATH=${makeBinPath (with pkgs; [ coreutils findutils inotify-tools ])}
-        bin_dir=~/.vscode-server/bin
+        bin_dir=${config.services.vscode-server.path}/bin
 
         # Fix any existing symlinks before we enter the inotify loop.
         if [[ -e $bin_dir ]]; then


### PR DESCRIPTION
The location of the server is currently hardcoded into `~/.vscode-server`.

This PR allows to change this path from the default, if the user changed this location in VS code settings.