### PR TITLE
Support CUDA in WSL2

### DIFF
--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -30,7 +30,10 @@ let
     }) ++ extraFHSPackages pkgs;
 
     extraBuildCommands = ''
-      cp -rsHf /usr/lib/wsl usr/lib/wsl
+      if [[ -d /usr/lib/wsl ]]
+      then
+        cp -rsHf /usr/lib/wsl usr/lib/wsl
+      fi
     '';
 
     runScript = "${nodejsPackage}/bin/node";

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -29,6 +29,12 @@ let
       ;
     }) ++ extraFHSPackages pkgs;
 
+    extraBwrapArgs [
+      "--bind-try"
+      "/usr/lib/wsl/lib"
+      "/usr/lib/wsl/lib"
+    ]
+
     runScript = "${nodejsPackage}/bin/node";
 
     meta = {

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -30,7 +30,7 @@ let
     }) ++ extraFHSPackages pkgs;
 
     extraBuildCommands = ''
-      cp -rsHf /usr/lib/wsl "usr/lib/wsl"
+      cp -rsHf ${/usr/lib/wsl} usr/lib/wsl
     '';
 
     runScript = "${nodejsPackage}/bin/node";

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -30,7 +30,7 @@ let
     }) ++ extraFHSPackages pkgs;
 
     extraBuildCommands = ''
-      cp -rsHf ${/usr/lib/wsl} usr/lib/wsl
+      cp -rsHf /usr/lib/wsl usr/lib/wsl
     '';
 
     runScript = "${nodejsPackage}/bin/node";

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -29,7 +29,9 @@ let
       ;
     }) ++ extraFHSPackages pkgs;
 
-    extraBindMounts = "/usr/lib/wsl/lib";
+    extraBuildCommands = ''
+      cp -rsHf /usr/lib/wsl "usr/lib/wsl"
+    '';
 
     runScript = "${nodejsPackage}/bin/node";
 

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -29,11 +29,11 @@ let
       ;
     }) ++ extraFHSPackages pkgs;
 
-    extraBwrapArgs [
+    extraBwrapArgs = [
       "--bind-try"
       "/usr/lib/wsl/lib"
       "/usr/lib/wsl/lib"
-    ]
+    ];
 
     runScript = "${nodejsPackage}/bin/node";
 

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -29,11 +29,7 @@ let
       ;
     }) ++ extraFHSPackages pkgs;
 
-    extraBwrapArgs = [
-      "--bind-try"
-      "/usr/lib/wsl/lib"
-      "/usr/lib/wsl/lib"
-    ];
+    extraBindMounts = "/usr/lib/wsl/lib";
 
     runScript = "${nodejsPackage}/bin/node";
 


### PR DESCRIPTION
`/usr/lib/wsl/lib` includes CUDA drivers for WSL2, which should be exposed to the FHS environment in order to use CUDA.

Note that both this PR and https://github.com/nix-community/NixOS-WSL/pull/221 are required in order to enable CUDA in WSL2 in the VS Code Terminal