### PR TITLE
Fix auto-patch script

### DIFF
--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -54,9 +54,41 @@ in writeShellScript "auto-fix-vscode-server.sh" ''
 
   patch_bin() {
     local bin_dir=$1 interp
+    
+    if [[ ! -d "$bin_dir" ]]; then
+      echo "Going back to sleep, this is not a directory."
+      return
+    fi
+
+    echo "Patching $bin_dir/node"
     ln -sfT ${nodejsWrapped}/bin/node "$bin_dir/node"
+    echo "Done patching node."
+
+    echo "Checking for helper binaries..."
+    local iter=0
+    while [[ ! -e "$bin_dir/node_modules/node-pty/build/Release/spawn-helper" && $iter -lt 50 ]]; do
+      (( iter++ ))
+      echo "Waiting for helper binaries to be populated... attempt $iter of 50"
+      sleep 0.1
+    done
+
+    if [[ $iter -ge 50 ]]; then
+      echo "Timed out waiting for helper binaries after 5s!"
+    else
+      echo "Found helper binaries."
+    fi
+
+    echo "Attempting patches within $bin_dir"
     while read -rd ''' bin; do
-      interp=$(patchelf --print-interpreter "$bin" 2>/dev/null) && [[ $interp != "$node_rpath" ]] || continue
+      if ! interp=$(patchelf --print-interpreter "$bin" 2>/dev/null); then
+        # skip, not patchable (statically linked or non-ELF)
+        continue
+      fi
+      if [[ "$interp" == "$node_interp" ]]; then
+        echo "Skipping $bin as it's already patched"
+        continue
+      fi
+      echo "Patching $bin..."
       patchelf --set-interpreter "$node_interp" --set-rpath "$node_rpath" "$bin"
       patchelf --shrink-rpath "$bin"
     done < <(find "$bin_dir" -type f -perm -100 -printf '%p\0')
@@ -66,17 +98,18 @@ in writeShellScript "auto-fix-vscode-server.sh" ''
   if [[ -e $bins_dir ]]; then
     while read -rd ''' bin_dir; do
       patch_bin "$bin_dir"
-    done < <(find "$bins_dir" -mindepth 1 -maxdepth 1 -printf '%p\0')
+    done < <(find "$bins_dir" -type d -mindepth 1 -maxdepth 1 -printf '%p\0')
   else
     mkdir -p "$bins_dir"
   fi
 
   while IFS=: read -r bin_dir event; do
-    # A new version of the VS Code Server is being created.
     if [[ $event == 'CREATE,ISDIR' ]]; then
+      echo "VSCode Server is being created at $bin_dir"
       # Create a trigger to know when their node is being created and replace it for our symlink.
       touch "$bin_dir/node"
       inotifywait -qq -e DELETE_SELF "$bin_dir/node"
+      echo "VSCode Server nodejs binary is ready for patching"
       patch_bin "$bin_dir"
     # The monitored directory is deleted, e.g. when "Uninstall VS Code Server from Host" has been run.
     elif [[ $event == DELETE_SELF ]]; then

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -67,7 +67,7 @@ in writeShellScript "auto-fix-vscode-server.sh" ''
     echo "Checking for helper binaries..."
     local iter=0
     while [[ ! -e "$bin_dir/node_modules/node-pty/build/Release/spawn-helper" && $iter -lt 50 ]]; do
-      (( iter++ ))
+      (( ++iter ))
       echo "Waiting for helper binaries to be populated... attempt $iter of 50"
       sleep 0.1
     done


### PR DESCRIPTION
- Only run patch_bin on directories
- Wait 5s for spawn-helper to appear before attempting patch
- Detect already-patched binaries correctly
- Fix shellcheck warning by using less-ambiguous syntax
- Increase logging

Fixes #45 