### PR TITLE
Better trigger for when to start patching files

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,4 +168,8 @@ Tested on VS Code version 1.63.2, connecting to the NixOS remote from a MacOS ho
 
 ## Future work
 
+### Patching extensions
 More work is needed to see if it is possible to also automatically patch binaries in VS Code extensions without using the FHS compatible environment.
+
+### WSL support
+Some work has been done to get WSL to work out of the box, but it is not working quite yet.

--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -4,26 +4,29 @@ moduleConfig:
 {
   options.services.vscode-server = let
     inherit (lib) mkEnableOption mkOption;
-    inherit (lib.types) bool listOf package str unspecified;
+    inherit (lib.types) listOf nullOr package str;
   in {
     enable = mkEnableOption "VS Code Server";
 
+    enableFHS = mkEnableOption "a FHS compatible environment";
+
     nodejsPackage = mkOption {
-      type = package;
-      default = pkgs.nodejs-16_x;
-      example = pkgs.nodejs-18_x;
+      type = nullOr package;
+      default = null;
+      example = pkgs.nodejs-16_x;
       description = ''
-        The Node.js package of the Node.js version used by VS Code version of the client.
+        Whether to use a specific Node.js rather than the version supplied by VS Code server.
       '';
     };
 
-    enableFHS = mkEnableOption "a FHS compatible environment";
-
-    extraFHSPackages = mkOption {
-      type = unspecified;
-      default = pkgs: [ ];
+    extraRuntimeDependencies = mkOption {
+      type = listOf package;
+      default = [ ];
       description = ''
-        A function to add extra packages to the FHS compatible environment.
+        A list of extra packages to use as runtime dependencies.
+        It is used to determine the RPATH to automatically patch ELF binaries with,
+        or when a FHS compatible environment has been enabled,
+        to determine its extra target packages.
       '';
     };
 
@@ -37,17 +40,25 @@ moduleConfig:
     };
   };
 
-  config = let cfg = config.services.vscode-server; in lib.mkIf cfg.enable (moduleConfig {
-    name = "auto-fix-vscode-server";
-    description = "Automatically fix the VS Code server used by the remote SSH extension";
-    serviceConfig = {
-      # When a monitored directory is deleted, it will stop being monitored.
-      # Even if it is later recreated it will not restart monitoring it.
-      # Unfortunately the monitor does not kill itself when it stops monitoring,
-      # so rather than creating our own restart mechanism, we leverage systemd to do this for us.
-      Restart = "always";
-      RestartSec = 0;
-      ExecStart = "${pkgs.callPackage ../../pkgs/auto-fix-vscode-server.nix (removeAttrs cfg [ "enable" ])}";
-    };
-  });
+  config = let
+    inherit (lib) mkDefault mkIf mkMerge;
+    cfg = config.services.vscode-server;
+  in mkIf cfg.enable (mkMerge [
+    {
+      services.vscode-server.nodejsPackage = mkIf cfg.enableFHS (mkDefault pkgs.nodejs-16_x);
+    }
+    (moduleConfig {
+      name = "auto-fix-vscode-server";
+      description = "Automatically fix the VS Code server used by the remote SSH extension";
+      serviceConfig = {
+        # When a monitored directory is deleted, it will stop being monitored.
+        # Even if it is later recreated it will not restart monitoring it.
+        # Unfortunately the monitor does not kill itself when it stops monitoring,
+        # so rather than creating our own restart mechanism, we leverage systemd to do this for us.
+        Restart = "always";
+        RestartSec = 0;
+        ExecStart = "${pkgs.callPackage ../../pkgs/auto-fix-vscode-server.nix (removeAttrs cfg [ "enable" ])}";
+      };
+    })
+  ]);
 }

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -34,6 +34,9 @@ let
     targetPkgs = _: runtimeDependencies;
     extraBuildCommands = ''
       if [[ -d /usr/lib/wsl ]]; then
+        # Recursively symlink the lib files necessary for WSL
+        # to properly function under the FHS compatible environment.
+        # The -s stands for symbolic link.
         cp -rsHf /usr/lib/wsl usr/lib/wsl
       fi
     '';

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -59,8 +59,8 @@ let
     # NOTE: We don't log here because it won't show up in the output of the user service.
 
     # Check if the installation is already full patched.
-    if (( $(< "$bin_dir/.patched") )); then
-      continue;
+    if [[ ! -e "$bin_dir/.patched" ]] || (( $(< "$bin_dir/.patched") )); then
+      return 0
     fi
 
     while read -rd ''' elf; do
@@ -145,7 +145,7 @@ in writeShellScript "auto-fix-vscode-server.sh" ''
       echo "VS Code server is being installed in $actual_dir..." >&2
       touch "$actual_dir/node"
       inotifywait -qq -e DELETE_SELF "$actual_dir/node"
-      patch_bin "$actual_dir" "$bin"
+      patch_bin "$bin"
     # The monitored directory is deleted, e.g. when "Uninstall VS Code Server from Host" has been run.
     elif [[ $event == DELETE_SELF ]]; then
       # See the comments above Restart in the service config.

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -110,7 +110,7 @@ in writeShellScript "auto-fix-vscode-server.sh" ''
       #!/usr/bin/env sh
 
       # The core utilities are missing in the case of WSL, but required by Node.js.
-      PATH="''${PATH:+''${PATH}:}${makeBinPath [ coreutils ]}"
+      PATH="\''${PATH:+\''${PATH}:}${makeBinPath [ coreutils ]}"
 
       # We leave the rest up to the Bash script
       # to keep having to deal with `sh` compatibility to a minimum.

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -1,81 +1,83 @@
-{ lib, writeShellScript, coreutils, findutils, inotify-tools, patchelf, nodejs-16_x, buildFHSUserEnv
-, nodejsPackage ? nodejs-16_x
+{ lib, buildFHSUserEnv
+, writeShellScript, coreutils, findutils, inotify-tools, patchelf
+, stdenv, curl, icu, libunwind, libuuid, lttng-ust, openssl, zlib, krb5
 , enableFHS ? false
-, extraFHSPackages ? (pkgs: [ ])
+, nodejsPackage ? null
+, extraRuntimeDependencies ? [ ]
 , installPath ? "~/.vscode-server"
 }:
 
 let
-  nodejs = nodejsPackage;
+  inherit (lib) makeBinPath makeLibraryPath optionalString;
 
   # Based on: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/editors/vscode/generic.nix
-  nodejsFHS = buildFHSUserEnv {
+  runtimeDependencies = [
+    stdenv.cc.libc
+    stdenv.cc.cc
+
+    # dotnet
+    curl
+    icu
+    libunwind
+    libuuid
+    lttng-ust
+    openssl
+    zlib
+
+    # mono
+    krb5
+  ];
+
+  nodejs = nodejsPackage;
+  nodejsFHS = buildFHSUserEnv ({
     name = "node";
-
-    # additional libraries which are commonly needed for extensions
-    targetPkgs = pkgs: (builtins.attrValues {
-      inherit (pkgs)
-        # ld-linux-x86-64-linux.so.2 and others
-        glibc
-
-        # dotnet
-        curl
-        icu
-        libunwind
-        libuuid
-        lttng-ust
-        openssl
-        zlib
-
-        # mono
-        krb5
-      ;
-    }) ++ extraFHSPackages pkgs;
-
+    targetPkgs = _: runtimeDependencies;
+    extraBuildCommands = ''
+      if [[ -d /usr/lib/wsl ]]; then
+        cp -rsHf /usr/lib/wsl usr/lib/wsl
+      fi
+    '';
     runScript = "${nodejs}/bin/node";
-
     meta = {
       description = ''
         Wrapped variant of Node.js which launches in an FHS compatible envrionment,
-        which should allow for easy usage of extensions without nix-specific modifications.
+        which should allow for easy usage of extensions without Nix-specific modifications.
       '';
     };
-  };
-
+  });
   nodejsWrapped = if enableFHS then nodejsFHS else nodejs;
 
-  patchScript = writeShellScript "patch-vscode-server.sh" ''
+  patchELFScript = writeShellScript "patchelf-vscode-server.sh" ''
     set -euo pipefail
-    PATH=${lib.makeBinPath [ coreutils findutils patchelf ]}
+    PATH=${makeBinPath [ coreutils findutils patchelf ]}
+    INTERP=$(cat ${stdenv.cc}/nix-support/dynamic-linker)
+    RPATH=${makeLibraryPath runtimeDependencies}
     bin_dir=$1
 
-    echo "Patching VS Code server installation in $bin_dir..." >&2
+    # NOTE: We don't log here because it won't show up in the output of the user service.
 
-    node_interp=$(patchelf --print-interpreter ${nodejs}/bin/node)
-    node_rpath=$(patchelf --print-rpath ${nodejs}/bin/node)
-    while read -rd ''' bin; do
+    while read -rd ''' elf; do
       # Check if binary is patchable, e.g. not a statically-linked or non-ELF binary.
-      if ! interp=$(patchelf --print-interpreter "$bin" 2>/dev/null); then
+      if ! interp=$(patchelf --print-interpreter "$elf" 2>/dev/null); then
         continue
       fi
 
       # Check if it is not already patched for Nix.
-      if [[ $interp == "$node_interp" ]]; then
+      if [[ $interp == "$INTERP" ]]; then
         continue
       fi
 
       # Patch the binary based on the binary of Node.js,
       # which should include all dependencies they might need.
-      patchelf --set-interpreter "$node_interp" --set-rpath "$node_rpath" "$bin"
+      patchelf --set-interpreter "$INTERP" --set-rpath "$RPATH" "$elf"
 
       # The actual dependencies are probably less than that of Node.js,
       # so shrink the RPATH to only keep those that are actually needed.
-      patchelf --shrink-rpath "$bin"
-
-      echo "Patched $bin." >&2
+      patchelf --shrink-rpath "$elf"
     done < <(find "$bin_dir" -type f -perm -100 -printf '%p\0')
 
-    touch "$bin_dir/.patched"
+    # Mark the bin directory as being patched.
+    echo 1 > "$bin_dir/.patched"
   '';
 
 in writeShellScript "auto-fix-vscode-server.sh" ''
@@ -86,22 +88,32 @@ in writeShellScript "auto-fix-vscode-server.sh" ''
   patch_bin_dir () {
     local bin_dir=$1
 
-    if [[ -e $bin_dir/node.orig ]]; then
+    if [[ -e $bin_dir/.patched ]]; then
       return 0
     fi
 
-    mv "$bin_dir/node" "$bin_dir/node.orig"
-    cat <<EOF > "$bin_dir/node"
-#!/usr/bin/env bash
+    echo "Patching Node.js of VS Code server installation in $bin_dir..." >&2
 
-# Patch the VS Code server installation only if it is not already patched.
-if [[ ! -e '$bin_dir/.patched' ]]; then
-  ${patchScript} '$bin_dir'
-fi
+    ${optionalString (nodejsWrapped != null) ''
+      ln -sfT ${nodejsWrapped}/bin/node "$bin_dir/node"
+    ''}
 
-exec '$bin_dir/node.orig' "\$@"
-EOF
-    chmod +x "$bin_dir/node"
+    ${optionalString (!enableFHS) ''
+      mv "$bin_dir/node" "$bin_dir/node.orig"
+      cat <<EOF > "$bin_dir/node"
+      #!/usr/bin/env bash
+
+      # Patch the VS Code server installation only if it is not already patched.
+      if ! (( \$(< '$bin_dir/.patched') )); then
+        ${patchELFScript} '$bin_dir'
+      fi
+
+      exec '$bin_dir/node.orig' "\$@"
+      EOF
+      chmod +x "$bin_dir/node"
+    ''}
+
+    echo 0 > "$bin_dir/.patched"
   }
 
   # Fix any existing symlinks before we enter the inotify loop.
@@ -116,7 +128,7 @@ EOF
   while IFS=: read -r bin_dir event; do
     # A new version of the VS Code Server is being created.
     if [[ $event == 'CREATE,ISDIR' ]]; then
-      echo "VS Code server is being installed in $bin_dir..."
+      echo "VS Code server is being installed in $bin_dir..." >&2
       touch "$bin_dir/node"
       inotifywait -qq -e DELETE_SELF "$bin_dir/node"
       patch_bin_dir "$bin_dir"

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -110,7 +110,7 @@ in writeShellScript "auto-fix-vscode-server.sh" ''
       #!/usr/bin/env sh
 
       # The core utilities are missing in the case of WSL, but required by Node.js.
-      PATH=${makeBinPath [ coreutils ]}
+      PATH="''${PATH:+''${PATH}:}${makeBinPath [ coreutils ]}"
 
       # We leave the rest up to the Bash script
       # to keep having to deal with `sh` compatibility to a minimum.


### PR DESCRIPTION
Based on PRs #44 and #46 I have made some changes that should make it so that it only starts patching files when all files are properly installed, including any potential additional helper binaries. It has been working well in my tests, but I thought so too when I merged my last changes and their were still some major issues then, hence this PR. Hopefully I can get some feedback before I start merging it again.