### PR TITLE
Add shellcheck flake check

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655361562,
-        "narHash": "sha256-chPaIIhmdL6jdZWpf/K6yQCsuBNOYuMqbJsNpLfrdTE=",
+        "lastModified": 1672441588,
+        "narHash": "sha256-jx5kxOyeObnVD44HRebKYL3cjWrcKhhcDmEYm0/naDY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0b59d075675dc28bf9ebab466033280096c8d4fe",
+        "rev": "6a0d2701705c3cf6f42c15aa92b7885f1f8a477f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,13 @@
 {
   description = "NixOS VSCode server";
 
-  outputs = { self, nixpkgs }: {
+  outputs = { self, nixpkgs }: let
+    pkgs = import nixpkgs { system = "x86_64-linux"; };
+    auto-fix-vscode-server = pkgs.callPackage ./pkgs/auto-fix-vscode-server.nix {};
+  in {
     nixosModule = import ./modules/vscode-server;
     nixosModules.default = self.nixosModule;
     nixosModules.home = import ./modules/vscode-server/home.nix;
+    checks.x86_64-linux.auto-fix-vscode-server = auto-fix-vscode-server;
   };
 }

--- a/modules/vscode-server/module.nix
+++ b/modules/vscode-server/module.nix
@@ -57,7 +57,7 @@ moduleConfig:
         # so rather than creating our own restart mechanism, we leverage systemd to do this for us.
         Restart = "always";
         RestartSec = 0;
-        ExecStart = "${pkgs.callPackage ../../pkgs/auto-fix-vscode-server.nix (removeAttrs cfg [ "enable" ])}";
+        ExecStart = "${pkgs.callPackage ../../pkgs/auto-fix-vscode-server.nix (removeAttrs cfg [ "enable" ])}/bin/auto-fix-vscode-server";
       };
     })
   ]);

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -120,7 +120,7 @@ let
           PATH="\''${PATH:+\''${PATH}:}${makeBinPath [ coreutils ]}"
 
           # We leave the rest up to the Bash script
-          # to keep having to deal with `sh` compatibility to a minimum.
+          # to keep having to deal with 'sh' compatibility to a minimum.
           ${patchELFScript}/bin/patchelf-vscode-server '$bin_dir'
 
           # Let Node.js take over as if this script never existed.

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -62,7 +62,7 @@ let
 
       # Check if the installation is already full patched.
       if [[ ! -e "$bin_dir/.patched" ]] || (( $(< "$bin_dir/.patched") )); then
-        return 0
+        exit 0
       fi
 
       while read -rd ''' elf; do

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -1,6 +1,5 @@
 { lib, buildFHSUserEnv
-, writeShellApplication
-, writeShellScript, coreutils, findutils, inotify-tools, patchelf
+, writeShellApplication, coreutils, findutils, inotify-tools, patchelf
 , stdenv, curl, icu, libunwind, libuuid, lttng-ust, openssl, zlib, krb5
 , enableFHS ? false
 , nodejsPackage ? null

--- a/pkgs/auto-fix-vscode-server.nix
+++ b/pkgs/auto-fix-vscode-server.nix
@@ -1,4 +1,5 @@
 { lib, buildFHSUserEnv
+, writeShellApplication
 , writeShellScript, coreutils, findutils, inotify-tools, patchelf
 , stdenv, curl, icu, libunwind, libuuid, lttng-ust, openssl, zlib, krb5
 , enableFHS ? false
@@ -49,107 +50,112 @@ let
     };
   });
 
-  patchELFScript = writeShellScript "patchelf-vscode-server.sh" ''
-    set -euo pipefail
-    PATH=${makeBinPath [ coreutils findutils patchelf ]}
-    INTERP=$(< ${stdenv.cc}/nix-support/dynamic-linker)
-    RPATH=${makeLibraryPath runtimeDependencies}
-    bin_dir=$1
+  patchELFScript = writeShellApplication {
+    name = "patchelf-vscode-server";
+    runtimeInputs = [ coreutils findutils patchelf ];
+    text = ''
+      INTERP=$(< ${stdenv.cc}/nix-support/dynamic-linker)
+      RPATH=${makeLibraryPath runtimeDependencies}
+      bin_dir=$1
 
-    # NOTE: We don't log here because it won't show up in the output of the user service.
+      # NOTE: We don't log here because it won't show up in the output of the user service.
 
-    # Check if the installation is already full patched.
-    if [[ ! -e "$bin_dir/.patched" ]] || (( $(< "$bin_dir/.patched") )); then
-      return 0
-    fi
-
-    while read -rd ''' elf; do
-      # Check if binary is patchable, e.g. not a statically-linked or non-ELF binary.
-      if ! interp=$(patchelf --print-interpreter "$elf" 2>/dev/null); then
-        continue
+      # Check if the installation is already full patched.
+      if [[ ! -e "$bin_dir/.patched" ]] || (( $(< "$bin_dir/.patched") )); then
+        return 0
       fi
 
-      # Check if it is not already patched for Nix.
-      if [[ $interp == "$INTERP" ]]; then
-        continue
+      while read -rd ''' elf; do
+        # Check if binary is patchable, e.g. not a statically-linked or non-ELF binary.
+        if ! interp=$(patchelf --print-interpreter "$elf" 2>/dev/null); then
+          continue
+        fi
+
+        # Check if it is not already patched for Nix.
+        if [[ $interp == "$INTERP" ]]; then
+          continue
+        fi
+
+        # Patch the binary based on the binary of Node.js,
+        # which should include all dependencies they might need.
+        patchelf --set-interpreter "$INTERP" --set-rpath "$RPATH" "$elf"
+
+        # The actual dependencies are probably less than that of Node.js,
+        # so shrink the RPATH to only keep those that are actually needed.
+        patchelf --shrink-rpath "$elf"
+      done < <(find "$bin_dir" -type f -perm -100 -printf '%p\0')
+
+      # Mark the bin directory as being fully patched.
+      echo 1 > "$bin_dir/.patched"
+    '';
+  };
+
+  autoFixScript = writeShellApplication {
+    name = "auto-fix-vscode-server";
+    runtimeInputs = [ coreutils findutils inotify-tools ];
+    text = ''
+      bins_dir=${installPath}/bin
+
+      patch_bin () {
+        local bin=$1 actual_dir=$bins_dir/$1 bin_dir
+        bin=''${bin:0:40}
+        bin_dir=$bins_dir/$bin
+
+        if [[ -e $actual_dir/.patched ]]; then
+          return 0
+        fi
+
+        echo "Patching Node.js of VS Code server installation in $actual_dir..." >&2
+
+        ${optionalString (nodejs != null) ''
+          ln -sfT ${if enableFHS then nodejsFHS else nodejs}/bin/node "$actual_dir/node"
+        ''}
+
+        ${optionalString (!enableFHS) ''
+          mv "$actual_dir/node" "$actual_dir/node.orig"
+          cat <<EOF > "$actual_dir/node"
+          #!/usr/bin/env sh
+
+          # The core utilities are missing in the case of WSL, but required by Node.js.
+          PATH="\''${PATH:+\''${PATH}:}${makeBinPath [ coreutils ]}"
+
+          # We leave the rest up to the Bash script
+          # to keep having to deal with `sh` compatibility to a minimum.
+          ${patchELFScript}/bin/patchelf-vscode-server '$bin_dir'
+
+          # Let Node.js take over as if this script never existed.
+          exec '$bin_dir/node.orig' "\$@"
+          EOF
+          chmod +x "$actual_dir/node"
+        ''}
+
+        # Mark the bin directory as being patched.
+        echo 0 > "$bin_dir/.patched"
+      }
+
+      # Fix any existing symlinks before we enter the inotify loop.
+      if [[ -e $bins_dir ]]; then
+        while read -rd ''' bin; do
+          patch_bin "$bin"
+        done < <(find "$bins_dir" -mindepth 1 -maxdepth 1 -type d -printf '%P\0')
+      else
+        mkdir -p "$bins_dir"
       fi
 
-      # Patch the binary based on the binary of Node.js,
-      # which should include all dependencies they might need.
-      patchelf --set-interpreter "$INTERP" --set-rpath "$RPATH" "$elf"
-
-      # The actual dependencies are probably less than that of Node.js,
-      # so shrink the RPATH to only keep those that are actually needed.
-      patchelf --shrink-rpath "$elf"
-    done < <(find "$bin_dir" -type f -perm -100 -printf '%p\0')
-
-    # Mark the bin directory as being fully patched.
-    echo 1 > "$bin_dir/.patched"
-  '';
-
-in writeShellScript "auto-fix-vscode-server.sh" ''
-  set -euo pipefail
-  PATH=${makeBinPath [ coreutils findutils inotify-tools ]}
-  bins_dir=${installPath}/bin
-
-  patch_bin () {
-    local bin=$1 actual_dir=$bins_dir/$1 bin_dir
-    bin=''${bin:0:40}
-    bin_dir=$bins_dir/$bin
-
-    if [[ -e $actual_dir/.patched ]]; then
-      return 0
-    fi
-
-    echo "Patching Node.js of VS Code server installation in $actual_dir..." >&2
-
-    ${optionalString (nodejs != null) ''
-      ln -sfT ${if enableFHS then nodejsFHS else nodejs}/bin/node "$actual_dir/node"
-    ''}
-
-    ${optionalString (!enableFHS) ''
-      mv "$actual_dir/node" "$actual_dir/node.orig"
-      cat <<EOF > "$actual_dir/node"
-      #!/usr/bin/env sh
-
-      # The core utilities are missing in the case of WSL, but required by Node.js.
-      PATH="\''${PATH:+\''${PATH}:}${makeBinPath [ coreutils ]}"
-
-      # We leave the rest up to the Bash script
-      # to keep having to deal with `sh` compatibility to a minimum.
-      ${patchELFScript} '$bin_dir'
-
-      # Let Node.js take over as if this script never existed.
-      exec '$bin_dir/node.orig' "\$@"
-      EOF
-      chmod +x "$actual_dir/node"
-    ''}
-
-    # Mark the bin directory as being patched.
-    echo 0 > "$bin_dir/.patched"
-  }
-
-  # Fix any existing symlinks before we enter the inotify loop.
-  if [[ -e $bins_dir ]]; then
-    while read -rd ''' bin; do
-      patch_bin "$bin"
-    done < <(find "$bins_dir" -mindepth 1 -maxdepth 1 -type d -printf '%P\0')
-  else
-    mkdir -p "$bins_dir"
-  fi
-
-  while IFS=: read -r bin event; do
-    # A new version of the VS Code Server is being created.
-    if [[ $event == 'CREATE,ISDIR' ]]; then
-      actual_dir=$bins_dir/$bin
-      echo "VS Code server is being installed in $actual_dir..." >&2
-      touch "$actual_dir/node"
-      inotifywait -qq -e DELETE_SELF "$actual_dir/node"
-      patch_bin "$bin"
-    # The monitored directory is deleted, e.g. when "Uninstall VS Code Server from Host" has been run.
-    elif [[ $event == DELETE_SELF ]]; then
-      # See the comments above Restart in the service config.
-      exit 0
-    fi
-  done < <(inotifywait -q -m -e CREATE,ISDIR -e DELETE_SELF --format '%f:%e' "$bins_dir")
-''
+      while IFS=: read -r bin event; do
+        # A new version of the VS Code Server is being created.
+        if [[ $event == 'CREATE,ISDIR' ]]; then
+          actual_dir=$bins_dir/$bin
+          echo "VS Code server is being installed in $actual_dir..." >&2
+          touch "$actual_dir/node"
+          inotifywait -qq -e DELETE_SELF "$actual_dir/node"
+          patch_bin "$bin"
+        # The monitored directory is deleted, e.g. when "Uninstall VS Code Server from Host" has been run.
+        elif [[ $event == DELETE_SELF ]]; then
+          # See the comments above Restart in the service config.
+          exit 0
+        fi
+      done < <(inotifywait -q -m -e CREATE,ISDIR -e DELETE_SELF --format '%f:%e' "$bins_dir")
+    '';
+  };
+in autoFixScript


### PR DESCRIPTION
https://github.com/msteen/nixos-vscode-server/blob/93517f56ac57dbe07a2eb209cc51e4f1725ebb51/pkgs/auto-fix-vscode-server.nix#L63

> return: can only \`return' from a function or sourced script

https://github.com/msteen/nixos-vscode-server/blob/93517f56ac57dbe07a2eb209cc51e4f1725ebb51/pkgs/auto-fix-vscode-server.nix#L119

> sh: command not found

We keep running into typos that aren't detected until runtime. Although `shellcheck` doesn't see any problem with the first issue, it catches the second. Let's make it run `shellcheck` at build-time, and add a flake check for the default configuration.